### PR TITLE
Subscription Metrics - Analytics Engineering Test Project - Joe Gartenhaus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/
 .DS_Store
 
 target/
+.user.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 
 venv/
 .DS_Store
+
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target/
 dbt_packages/
 logs/
+
+venv/
+.DS_Store

--- a/macros/date_macros.sql
+++ b/macros/date_macros.sql
@@ -1,0 +1,49 @@
+{# This macro returns a string in the format of #Q given a month number #}
+{% macro quarter(month_num) %}
+
+        case
+            when {{ month_num }} between 1 and 3 then '1Q'
+            when {{ month_num }} between 4 and 6 then '2Q'
+            when {{ month_num }} between 7 and 9 then '3Q'
+            when {{ month_num }} between 10 and 12 then '4Q'
+            else 'ERR'
+        end as quarter
+
+{% endmacro %}
+
+{# This macro returns the month name given a month number #}
+{% macro month_name(month_num) %}
+
+        case
+            when {{ month_num }} = 1 then 'January'
+            when {{ month_num }} = 2 then 'February'
+            when {{ month_num }} = 3 then 'March'
+            when {{ month_num }} = 4 then 'April'
+            when {{ month_num }} = 5 then 'May'
+            when {{ month_num }} = 6 then 'June'
+            when {{ month_num }} = 7 then 'July'
+            when {{ month_num }} = 8 then 'August'
+            when {{ month_num }} = 9 then 'September'
+            when {{ month_num }} = 10 then 'October'
+            when {{ month_num }} = 11 then 'November'
+            when {{ month_num }} = 12 then 'December'
+            else 'ERR'
+        end as month_name
+
+{% endmacro %}
+
+{# This macro returns the weekday name given a weekday number #}
+{% macro weekday_name(day_of_week) %}
+
+        case
+            when {{ day_of_week }} = 1 then 'Sunday'
+            when {{ day_of_week }} = 2 then 'Monday'
+            when {{ day_of_week }} = 3 then 'Tuesday'
+            when {{ day_of_week }} = 4 then 'Wednesday'
+            when {{ day_of_week }} = 5 then 'Thursday'
+            when {{ day_of_week }} = 6 then 'Friday'
+            when {{ day_of_week }} = 7 then 'Saturday'
+            else 'ERR'
+        end as weekday_name
+
+{% endmacro %}

--- a/macros/date_macros.yml
+++ b/macros/date_macros.yml
@@ -1,0 +1,23 @@
+version: 2
+
+macros:
+  - name: quarter
+    description: "Returns 1/2/3/4Q depending on the input month"
+    arguments:
+      - name: month_num
+        type: column name or expression
+        description: "The name of a column, or an expression equating to month numbers [1-12]"
+
+  - name: month_name
+    description: "Returns January, February, etc depending on the input month"
+    arguments:
+      - name: month_num
+        type: column name or expression
+        description: "The name of a column, or an expression equating to month numbers [1-12]"
+
+  - name: weekday_name
+    description: "Returns Sunday, Monday, etc depending on the input weekday_num"
+    arguments:
+      - name: weekday_num
+        type: column name or expression
+        description: "The name of a column, or an expression equating to month numbers [1-7]"

--- a/models/marts/subscriptions/fct_cancellations.sql
+++ b/models/marts/subscriptions/fct_cancellations.sql
@@ -1,0 +1,36 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "cancelled_date",
+                "data_type": "date",
+                "granularity": "day"
+        },               
+        cluster_by = 'customer_id'
+    )
+}}
+
+with
+
+cancellations as (
+
+    select * from {{ ref('stg_recharge_subscriptions') }}
+    where is_valid_cancellation
+
+)
+
+, final as (
+
+    select
+          cancelled_at
+        , cancelled_date
+        , customer_id
+        , 'Subscription Cancelled' as action
+        , id
+        , customer_subscription_number
+
+    from cancellations
+
+)
+
+select * from final

--- a/models/marts/subscriptions/fct_cancellations.yml
+++ b/models/marts/subscriptions/fct_cancellations.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: fct_cancellations
+    description: "Fact Model containing all cancellations (including implied cancelations)"
+    columns:
+      - name: cancelled_at
+        description: "Timestamp of subscription cancellation (EST)"
+      - name: cancelled_date
+        description: "Date of subscription_cancellation (EST)"
+      - name: customer_id
+        description: "Customer ID"
+        tests:
+          - not_null
+      - name: action
+        description: "Suscription Cancelled in this table"
+      - name: id
+        description: "Subscription ID"
+        tests:
+          - not_null
+          - unique
+      - name: customer_subscription_number
+        description: Sequential number of created order tied to this cancellation.
+

--- a/models/marts/subscriptions/fct_subscriptions.sql
+++ b/models/marts/subscriptions/fct_subscriptions.sql
@@ -1,0 +1,35 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "created_date",
+                "data_type": "date",
+                "granularity": "day"
+        },               
+        cluster_by = 'customer_id'
+    )
+}}
+
+with
+
+subscriptions as (
+
+    select * from {{ ref('stg_recharge_subscriptions') }}
+
+)
+
+, final as (
+
+    select
+          created_at
+        , created_date
+        , customer_id
+        , 'Subscription Created' as action
+        , id
+        , customer_subscription_number
+
+    from subscriptions
+
+)
+
+select * from final

--- a/models/marts/subscriptions/fct_subscriptions.yml
+++ b/models/marts/subscriptions/fct_subscriptions.yml
@@ -1,0 +1,23 @@
+version: 2
+
+models:
+  - name: fct_subscriptions
+    description: "Fact Model containing all subscriptions"
+    columns:
+      - name: created_at
+        description: "Timestamp of subscription creation (EST)"
+      - name: created_date
+        description: "Date of subscription creation (EST)"
+      - name: customer_id
+        description: "Customer ID"
+        tests:
+          - not_null
+      - name: action
+        description: "Suscription created in this table"
+      - name: id
+        description: "Subscription ID"
+        tests:
+          - not_null
+          - unique
+      - name: customer_subscription_number
+        description: Sequential number of customer's order.

--- a/models/reports/intermediate/int_date_customer_spine.sql
+++ b/models/reports/intermediate/int_date_customer_spine.sql
@@ -1,0 +1,21 @@
+{{
+    config(materialized='ephemeral')
+}}
+
+with
+
+calendar as ( select * from {{ ref('calendar') }} )
+
+, customers as ( select distinct customer_id from {{ ref('stg_recharge_subscriptions') }} )
+
+, customer_date_spine as (
+
+    select
+          calendar.date
+        , customers.customer_id
+    from calendar
+    cross join customers
+
+)
+
+select * from customer_date_spine

--- a/models/reports/intermediate/int_subscription_events.sql
+++ b/models/reports/intermediate/int_subscription_events.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        },               
+        cluster_by = 'customer_id'
+    )
+}}
+
+/* This model creates a unified event stream for subscription creation and cancellation events */
+
+with
+
+subscriptions as ( select * from {{ ref('fct_subscriptions') }} )
+
+, cancellations as (select * from {{ ref('fct_cancellations') }} )
+
+, unioned as (
+
+    select created_at as event_ts, created_date as date, * except(created_at, created_date) from subscriptions
+
+    union all
+
+    select cancelled_at as event_ts, cancelled_date as date,  * except(cancelled_at, cancelled_date) from cancellations
+
+
+)
+
+select * from unioned

--- a/models/reports/intermediate/int_subscriptions_active.sql
+++ b/models/reports/intermediate/int_subscriptions_active.sql
@@ -1,0 +1,71 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+/* This model creates a metrics for active subscriptions */
+
+with
+
+subscriptions as ( select * from {{ ref('stg_recharge_subscriptions') }} )
+
+, customer_date_spine as (select * from {{ ref('int_date_customer_spine') }} )
+
+, calendar as ( select * from {{ ref('calendar') }} )
+
+, daily_status as (
+    /* Create a daily record for every customer_id & subscription id and determine if subscription is active on said day $*/
+    select
+
+          customer_date_spine.date
+        , customer_date_spine.customer_id
+        , subscriptions.id
+        , customer_date_spine.date >= subscriptions.created_date 
+            and customer_date_spine.date <= coalesce(subscriptions.cancelled_date, '2050-01-01') as is_active
+    
+    from customer_date_spine
+    inner join subscriptions using(customer_id)
+
+)
+
+, active_subscriptions as (
+
+    select
+          date
+        , count(distinct id) as subscriptions_active
+    from daily_status
+    where is_active
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, active_subscribers as (
+
+    select
+          date
+        , count(distinct customer_id) as subscribers_active
+    from daily_status
+    where is_active
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, final as (
+
+    select
+          date
+        , coalesce(subscriptions_active, 0) as subscriptions_active
+        , coalesce(subscribers_active, 0) as subscribers_active
+    from calendar
+    left join active_subscriptions using(date)
+    left join active_subscribers using(date)
+
+)
+
+select * from final

--- a/models/reports/intermediate/int_subscriptions_cancellations.sql
+++ b/models/reports/intermediate/int_subscriptions_cancellations.sql
@@ -1,0 +1,111 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+with
+
+events as ( 
+    /* Bring in Cancellation Events */
+    select * from {{ ref('int_subscription_events') }} 
+    where action = 'Subscription Cancelled'
+
+)
+
+, subscriptions as ( select * from {{ ref('stg_recharge_subscriptions') }} )
+
+, customer_date_spine as (select * from {{ ref('int_date_customer_spine') }})
+
+, calendar as ( select * from {{ ref('calendar') }} )
+
+, daily_status as (
+    /* Create a daily record for every customer_id & subscription id and determine if subscription is active on said day $*/
+    select
+
+          customer_date_spine.date
+        , customer_date_spine.customer_id
+        , subscriptions.id
+        , customer_date_spine.date >= subscriptions.created_date 
+            and customer_date_spine.date <= coalesce(subscriptions.cancelled_date, '2050-01-01') as is_active
+    
+    from customer_date_spine
+    inner join subscriptions using(customer_id)
+
+)
+
+, cancellation_events as (
+
+    select
+    
+          customer_date_spine.*
+        , events.id
+
+    from customer_date_spine
+    left join events on customer_date_spine.date = events.date
+        and customer_date_spine.customer_id  = events.customer_id
+
+)
+
+, cancelled_subscriptions as (
+
+    select
+          date
+        , count(distinct id) as subscriptions_cancelled
+    from cancellation_events
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, subscriber_active_status as (
+    /* Get active status for customer across subscriptions on a particular day
+       This is needed because subscribers can only be 'cancelled; if they are otherwise inactive */
+    select
+          date
+        , customer_id
+        , logical_or(is_active) as is_active
+    from daily_status
+    {{ dbt_utils.group_by(2) }}
+
+)
+
+, subscriber_active_to_cancelled as (
+    /* We want to identify subscribers who go from active to inactive the next day */
+    select
+          date
+        , customer_id
+        , is_active
+        , lag(is_active,1) over(partition by customer_id order by date asc) as prev_is_active
+    from subscriber_active_status
+
+)
+
+, cancelled_subscribers as (
+
+    select
+          date
+        , count(distinct customer_id) as subscribers_cancelled
+    from subscriber_active_to_cancelled
+    where prev_is_active and not is_active  /* This is it! */
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, final as (
+
+    select
+          date
+        , coalesce(subscriptions_cancelled, 0) as subscriptions_cancelled
+        , coalesce(subscribers_cancelled, 0) as subscribers_cancelled
+    from calendar
+    left join cancelled_subscriptions using(date)
+    left join cancelled_subscribers using(date)
+
+)
+
+select * from final

--- a/models/reports/intermediate/int_subscriptions_churned.sql
+++ b/models/reports/intermediate/int_subscriptions_churned.sql
@@ -1,0 +1,93 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+with
+
+subscriptions as ( select * from {{ ref('stg_recharge_subscriptions') }} )
+
+, customer_date_spine as (select * from {{ ref('int_date_customer_spine') }} )
+
+, calendar as ( select * from {{ ref('calendar') }} )
+
+, daily_status as (
+    /* Create a daily record for every customer_id & subscription id and determine if subscription is active on said day */
+    select
+
+          customer_date_spine.date
+        , customer_date_spine.customer_id
+        , subscriptions.id
+        , subscriptions.customer_subscription_number
+        , customer_date_spine.date >= subscriptions.created_date 
+            and customer_date_spine.date <= coalesce(subscriptions.cancelled_date, '2050-01-01') as is_active
+    
+    from customer_date_spine
+    inner join subscriptions using(customer_id)
+
+)
+
+, churned_subscriptions_all as (
+    /* Find subscriptions churned subscriptions (cancelled and not otherwise active) $*/
+    select
+          daily_status.date
+        , subscriptions.id
+    from daily_status
+    left join subscriptions using(id)
+    where daily_status.date > subscriptions.created_date
+    and is_valid_cancellation
+    and not is_active
+
+)
+    
+, churned_subscriptions as (
+
+    select
+          date
+        , count(distinct id) as subscriptions_churned
+    from churned_subscriptions_all
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, churned_subscribers_all as (
+    /* Find subscribers who are went inactive after their first subscription $*/
+    select
+          daily_status.date
+        , daily_status.customer_id
+    from daily_status
+    inner join subscriptions using(customer_id)
+    where daily_status.date > subscriptions.created_date
+    and daily_status.customer_subscription_number = 1
+    and not daily_status.is_active
+    
+)
+
+, churned_subscribers as (
+
+    select
+          date
+        , count(distinct customer_id) as subscribers_churned
+    from churned_subscribers_all
+    {{ dbt_utils.group_by(1) }}
+)
+
+, final as (
+
+    select
+          date
+        , coalesce(subscriptions_churned, 0) as subscriptions_churned
+        , coalesce(subscribers_churned, 0) as subscribers_churned
+    from calendar
+    left join churned_subscriptions using(date)
+    left join churned_subscribers using(date)
+
+)
+
+select * from final

--- a/models/reports/intermediate/int_subscriptions_new.sql
+++ b/models/reports/intermediate/int_subscriptions_new.sql
@@ -1,0 +1,72 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+with
+
+events as ( 
+    /* Bring in New Subscription Events */
+    select * from {{ ref('int_subscription_events') }} 
+    where action = 'Subscription Created'
+
+)
+
+, customer_date_spine as (select * from {{ ref('int_date_customer_spine') }} )
+
+, calendar as ( select * from {{ ref('calendar') }} )
+
+, subscription_events as (
+
+    select
+    
+          customer_date_spine.*
+        , events.id
+        , events.customer_subscription_number
+
+    from customer_date_spine
+    left join events on customer_date_spine.date = events.date
+        and customer_date_spine.customer_id  = events.customer_id
+
+)
+
+, new_subscriptions as (
+
+    select
+          date
+        , count(distinct id) as subscriptions_new
+    from subscription_events
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, new_subscribers as (
+
+    select
+          date
+        , count(distinct customer_id) as subscribers_new
+    from subscription_events
+    where customer_subscription_number = 1
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, final as (
+
+    select
+          date
+        , coalesce(subscriptions_new, 0) as subscriptions_new
+        , coalesce(subscribers_new, 0) as subscribers_new
+    from calendar
+    left join new_subscriptions using(date)
+    left join new_subscribers using(date)
+
+)
+
+select * from final

--- a/models/reports/intermediate/int_subscriptions_returning.sql
+++ b/models/reports/intermediate/int_subscriptions_returning.sql
@@ -1,0 +1,75 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+with
+
+subscriptions as ( select * from {{ ref('stg_recharge_subscriptions') }} )
+
+, customer_date_spine as (select * from {{ ref('int_date_customer_spine') }} )
+
+, calendar as ( select * from {{ ref('calendar') }} )
+
+
+, subscriptions_all as (
+    /* Get all subscriptions */
+    select
+          created_at
+        , customer_id
+        , id
+    from subscriptions
+)
+
+, cancellations_all as (
+    /* Get all cancellation events */
+    select
+          cancelled_at
+        , customer_id
+        , id
+    from subscriptions
+    where is_valid_cancellation
+
+)
+
+, returning_subscriptions_all as (
+    /* Get subscriptions of customer's who subscribe after being cancelled */
+    select
+          subscriptions_all.created_at
+        , subscriptions_all.customer_id
+        , subscriptions_all.id
+    from subscriptions_all
+    inner join cancellations_all using(customer_id)
+    where subscriptions_all.created_at > cancellations_all.cancelled_at
+
+    qualify row_number() over(partition by id order by created_at asc) = 1  /* Get the first one */
+
+)
+
+, returning_subscriptions as (
+
+    select
+          date(created_at) as date
+        , count(distinct id) as subscriptions_returning
+    from returning_subscriptions_all
+    {{ dbt_utils.group_by(1) }}
+
+)
+
+, final as (
+
+    select
+          date
+        , coalesce(subscriptions_returning, 0) as subscriptions_returning
+    from calendar
+    left join returning_subscriptions using(date)
+
+)
+
+select * from final

--- a/models/reports/rpt_subscription_metrics.sql
+++ b/models/reports/rpt_subscription_metrics.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized='table',
+        partition_by = {
+                "field": "date",
+                "data_type": "date",
+                "granularity": "day"
+        }
+    )
+}}
+
+with 
+
+new_subs as ( select * from {{ ref('int_subscriptions_new') }} )
+
+, cancellations as ( select * from {{ ref('int_subscriptions_cancellations') }} )
+
+, active as ( select * from {{ ref('int_subscriptions_active') }} )
+
+, returning as ( select * from {{ ref('int_subscriptions_returning') }} )
+
+, churned as ( select * from {{ ref('int_subscriptions_churned') }} )
+
+, joined as (
+
+    select
+
+          new_subs.date
+        , new_subs.* except(date)
+        , cancellations.* except(date)
+        , active.* except(date)
+        , returning.* except(date)
+        , churned.* except(date)
+
+    from new_subs
+    inner join cancellations using(date)
+    inner join active using(date)
+    inner join returning using(date)
+    inner join churned using(date)
+
+)
+
+, rearranged as (
+
+    select
+        
+          date
+        
+        -- Subscription Metrics
+        , subscriptions_new
+        , subscriptions_returning
+        , subscriptions_cancelled
+        , subscriptions_active
+        , subscriptions_churned
+
+        -- Subscriber Metrics
+        , subscribers_new
+        , subscribers_cancelled
+        , subscribers_active
+        , subscribers_churned
+
+    from joined
+
+)
+
+select * from rearranged

--- a/models/reports/rpt_subscription_metrics.yml
+++ b/models/reports/rpt_subscription_metrics.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: rpt_subscription_metrics
+    description: "Reporting-level model containing various metrics related to Recharge subscriptions"
+    columns:
+      - name: date
+        description: "Unique subscription ID (primary key)"
+        tests:
+          - unique
+          - not_null
+      - name: subscriptions_new
+        description: "Number of new subscriptions created each day" 
+      - name: subscriptions_returning
+        description: "Number of subscriptions with customers who are returning"
+      - name: subscriptions_cancelled
+        description: "Number of subscriptions cancelled each day"
+      - name: subscriptions_active
+        description: "Daily snapshot of the number of active subscriptions each day"
+      - name: subscriptions_churned
+        description: "Daily snapshot of the total number of cancelled subscriptions each day"
+      - name: subscribers_new
+        description: "Number of new subscribers each day. A new subscriber is when a customer subscribes for the FIRST TIME"
+      - name: subscribers_cancelled
+        description: "Number of cancelled subscribers each day. A cancelled subscriber should have NO active subscriptions."
+      - name: subscribers_active
+        description: "Daily snapshot of the total number of active subscriber each day. An active subscriber should have AT LEAST ONE active subscriptions"
+      - name: subscribers_churned
+        description: "Daily snapshot of the total number of active subscriber each day. An active subscriber should have AT LEAST ONE active subscriptions"
+
+

--- a/models/staging/recharge/recharge.yml
+++ b/models/staging/recharge/recharge.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sources:
+  - name: recharge
+    database: wise-weaver-282922
+    schema: raw_data_sandbox
+
+    tables:
+      - name: subscriptions
+        identifier: acme1_recharge_subscriptions
+        description: Subscriptions table from Recharge
+
+

--- a/models/staging/recharge/stg_recharge_subscriptions.sql
+++ b/models/staging/recharge/stg_recharge_subscriptions.sql
@@ -17,14 +17,18 @@ with source as (
         , safe_cast(customer_id as int64) as customer_id
         
         -- Timestamps
-        , safe_cast(created_at as timestamp) as created_at_et
+        , safe_cast(created_at as timestamp) as created_at
         , safe_cast(created_at as date) as created_date
-        , safe_cast(cancelled_at as timestamp) as cancelled_at_et
-        , safe_cast(cancelled_at as date) as cancelled_date
+        , if(status = 'CANCELLED',coalesce(safe_cast(cancelled_at as timestamp), safe_cast(updated_at as timestamp)), safe_cast(cancelled_at as timestamp)) as cancelled_at
+        , if(status = 'CANCELLED',coalesce(safe_cast(cancelled_at as date), safe_cast(updated_at as date)), safe_cast(cancelled_at as date)) as cancelled_date
 
         -- Needed Fields
         , safe_cast(status as string) as status
         , safe_cast(cancellation_reason as string) as cancellation_reason
+        , status = 'CANCELLED' 
+            and (lower(cancellation_reason) not like '%max number of charge attempts%' 
+                    or cancellation_reason is null) as is_valid_cancellation
+        , row_number() over(partition by customer_id order by created_at asc) as customer_subscription_number
 
         -- No need to stage the rest of the data for this exercise, include the un-staged data anyway
         , * except(id, customer_id, created_at, cancelled_at, status, cancellation_reason)

--- a/models/staging/recharge/stg_recharge_subscriptions.sql
+++ b/models/staging/recharge/stg_recharge_subscriptions.sql
@@ -18,7 +18,9 @@ with source as (
         
         -- Timestamps
         , safe_cast(created_at as timestamp) as created_at_et
+        , safe_cast(created_at as date) as created_date
         , safe_cast(cancelled_at as timestamp) as cancelled_at_et
+        , safe_cast(cancelled_at as date) as cancelled_date
 
         -- Needed Fields
         , safe_cast(status as string) as status

--- a/models/staging/recharge/stg_recharge_subscriptions.sql
+++ b/models/staging/recharge/stg_recharge_subscriptions.sql
@@ -1,0 +1,34 @@
+{{
+    config(materialized='table')
+}}
+
+with source as (
+    
+    select * from {{ source('recharge', 'subscriptions') }}
+
+)
+
+, staging as (
+
+    select
+
+        -- IDs
+          safe_cast(id as int64) as id
+        , safe_cast(customer_id as int64) as customer_id
+        
+        -- Timestamps
+        , safe_cast(created_at as timestamp) as created_at_et
+        , safe_cast(cancelled_at as timestamp) as cancelled_at_et
+
+        -- Needed Fields
+        , safe_cast(status as string) as status
+        , safe_cast(cancellation_reason as string) as cancellation_reason
+
+        -- No need to stage the rest of the data for this exercise, include the un-staged data anyway
+        , * except(id, customer_id, created_at, cancelled_at, status, cancellation_reason)
+
+    from source
+
+)
+
+select * from staging

--- a/models/staging/recharge/stg_recharge_subscriptions.yml
+++ b/models/staging/recharge/stg_recharge_subscriptions.yml
@@ -15,8 +15,12 @@ models:
           - not_null
       - name: created_at_et
         description: "Timestamp subscription was created (EST)"
+      - name: created_date
+        description: "Date subscription was created"
       - name: cancelled_at_et
         description: "Timestamp subscription was cancelled (EST)"
+      - name: cancelled_date
+        descriptions: "Date subscription was cancelled"
       - name: status
         description: "Subscription status"
       - name: cancellation_reason

--- a/models/staging/recharge/stg_recharge_subscriptions.yml
+++ b/models/staging/recharge/stg_recharge_subscriptions.yml
@@ -13,15 +13,24 @@ models:
         description: "Customer ID"
         tests:
           - not_null
-      - name: created_at_et
+      - name: created_at
         description: "Timestamp subscription was created (EST)"
       - name: created_date
         description: "Date subscription was created"
-      - name: cancelled_at_et
+      - name: cancelled_at
         description: "Timestamp subscription was cancelled (EST)"
       - name: cancelled_date
         descriptions: "Date subscription was cancelled"
       - name: status
         description: "Subscription status"
+        tests:
+          - accepted_values:
+              values: ['CANCELLED','ACTIVE']
+              config:
+               severity: warn  # Warn if we get an unexpected value
       - name: cancellation_reason
         description: "Cancellation reason provided by customer"
+      - name: is_valid_cancellation
+        description: "Boolean indicating whether subscription should count against cancellations"
+      - name: customer_subscription_number
+        description: "Sequential count of subscriptions ordered by creation timestamp"

--- a/models/staging/recharge/stg_recharge_subscriptions.yml
+++ b/models/staging/recharge/stg_recharge_subscriptions.yml
@@ -1,0 +1,23 @@
+version: 2
+
+models:
+  - name: stg_recharge_subscriptions
+    description: Staged model for recharge subscriptions
+    columns:
+      - name: id
+        description: "Unique subscription ID (primary key)"
+        tests:
+          - unique
+          - not_null
+      - name: customer_id
+        description: "Customer ID"
+        tests:
+          - not_null
+      - name: created_at_et
+        description: "Timestamp subscription was created (EST)"
+      - name: cancelled_at_et
+        description: "Timestamp subscription was cancelled (EST)"
+      - name: status
+        description: "Subscription status"
+      - name: cancellation_reason
+        description: "Cancellation reason provided by customer"

--- a/models/utils/calendar.sql
+++ b/models/utils/calendar.sql
@@ -1,0 +1,54 @@
+{{
+    config(materialized='table')
+}}
+
+with date_spine as (
+
+    -- For this exercise, table starts at 2020-01-01
+    {{ dbt_utils.date_spine(
+        datepart="day",
+        start_date="cast('2020-01-01' as date)",
+        end_date="current_date()"
+        )
+    }}  
+
+)
+
+, casted as (
+
+    select cast(date_day as date) as date from date_spine
+
+)
+
+, basics as (
+
+    -- Let's add some additional items typically found in a calendar table
+
+    select 
+          *
+        , extract(year from date) as year
+        , extract(month from date) as month
+        , extract(week from date) as week
+        , extract(day from date) as day
+
+        , extract(dayofyear from date) as day_of_year
+        , extract(dayofweek from date) as day_of_week
+
+    from casted
+
+)
+
+, enhanced as (
+
+    select
+          *
+        -- Some more macros for good measure
+        , {{ quarter('month') }}
+        , {{ month_name('month') }}
+        , {{ weekday_name('day_of_week') }}
+
+    from basics
+
+)
+
+select * from enhanced

--- a/models/utils/calendar.yml
+++ b/models/utils/calendar.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: calendar
+    description: Utility calendar table
+    columns:
+      - name: date
+        description: "Calendar date"
+        tests:
+          - unique
+          - not_null
+      - name: year
+        description: "Calendar year (YYYY)"
+      - name: month
+        description: "Calendar month (1-12)"
+      - name: week
+        description: "Calendar week (0-53).  Week begins on Sunday; dates prior to first Sunday of the year are week 0."
+      - name: day
+        description: "Calendar day (1-31)"
+      - name: day_of_year
+        description: "Nth day of the year (beginning January 1st)"
+      - name: day_of_week
+        description: "Nth day of the week (beginning on Sunday)"
+      - name: quarter
+        description: "String of NQ, where N between 1-4 (Jan-Mar -> 1Q, Apr-Jun -> 2Q, Jul-Sep -> 3Q, Oct-Dec -> 4Q"
+      - name: month_name
+        description: "Month Name (January, February, etc)"
+      - name: weekday_name
+        description: "Weekday Name (Sunday, Monday, etc)"
+

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 0.8.5

--- a/profiles.yml
+++ b/profiles.yml
@@ -4,13 +4,18 @@ sm_test_project:
   target: default
   outputs:
     default:
-      dataset: "{{ env_var('OUTPUT_DATASET') }}"
-      keyfile: ./service_account.json
-      location: US
-      method: service-account
-      priority: interactive
-      project: wise-weaver-282922
-      threads: 6
-      timeout_seconds: 600
+      # dataset: "{{ env_var('OUTPUT_DATASET') }}"
+      # keyfile: ./service_account.json
+      # location: US
+      # method: service-account
+      # priority: interactive
+      # project: wise-weaver-282922
+      # threads: 6
+      # timeout_seconds: 600
+      # type: bigquery
       type: bigquery
-
+      method: oauth
+      threads: 6
+      timeout_seconds: 3600
+      schema: masterset_joe
+      project: wise-weaver-282922

--- a/service_account.json
+++ b/service_account.json
@@ -1,1 +1,12 @@
-
+{
+    "type": "service_account",
+    "project_id": "wise-weaver-282922",
+    "private_key_id": "1ab988be7711e85a5b0a44b81eafc4dba1b3c9a1",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC4A2zyh45aNoGI\nWT24/01kp/XxwsizwPa/B9pEhieeGXP5JwzCNeAEI83J2D3P5YJf7fd5pjeC7+aP\ngXfPf5lVxWFyRKkWWyTxEFRbyU1YKCyTCN/wRcxYiZwu3Jb8kI2Sgma8zYYRR6fo\nFeALzdr3fpjTPDa/8s0YM30Gz0BG+Vnz4l8U9E/+EC9ZMofC33thZyjHJTrkXXfk\nSBbpnM9kN72rDfVvW5SdrGmph5syoNcUJxBvbXMxzVIeWM8FR5MPzy87YN2h8n5b\nbg4tFET3sxIgQo9kcwJbwmCNR1+uaMPHy4wnNcVknybMi/ZC66ORk4aKpIfeLtR4\nFUfb8xp3AgMBAAECggEANUA8h4UGA4JRgvk8XOx445+dk2yIc0hsv4SQvBLMpTp9\nbsVHsm4v2VLZK0fKP38N9x/g5ZHd76ToJnBTkTc+Uu1vUUegXQlcS+yrVPKQ0Omz\nWIuRbrFsPNT53y/T+9wDNDpLa+jYGukPJKEr+I6GhufaZwq+V1b21kGUNWPFmKPy\nWLFKsQLdAOXAUCpvOuJL5pVAVeL6aSemMl1GfkuwXV2ZnqM10d7X+5tjxtTz0t7h\nCZcnjSLsNUpDQuGHy4J+WPs+zjkdx2LtS3dq2Y4TrwYs5/S0GCbzsCTYgen/J8gY\np3xGMjhFy72Yf9qYs1+B13ZE3dhIquL6L5EhqV5ENQKBgQD7GPu5FS4LhynBQ6SH\nSUT1YGI7izMkdx59kN2aRj7PsN3hQbsfCeUtKJHv2Q2SqiValmytlQZsKufQRGGj\n67HninsVuXeFjmrln45T1WNMpR86aNvClNLmkWV+e4J5yyL+cbvbw7q3hNCWbbhJ\nkthk2LzcGiY+k13yt6qvdsUS4wKBgQC7myWqk+H3LVFp8rghkXtHLaKuYnxKpkL2\nOOK5VPJsPSQcgtnY1Oh8cOg+bsz4jAJoorzOod2ZAc0kbbFK5rFLxY70Y0q6C9AL\ntMjWYqqTTPwCV4kxWPgLcWAiVK+2LnDKWz0ijnBpIOxz1EQ/rvxbHasmYNjMW39t\nDyPsI1YqXQKBgA1k/8iXwKUMyMVuflBZMDyGr7bNbiT71byNBcU9Cgy6OpvRjdHS\nDU+jYmWRBpBUUznJ3HJGCNmsUEFj5HGCGTNox7gY9K9DMaCeKlF+iJWGGWxcO5zd\no4J5LxjYLdWhaHR6TLMkdclkZFwh7jq+gpyekzSKkI+1/MT91zUU+N5RAoGBAJpm\nYMSXewSEDpokwbgW1J/LBjWBJowFc9zTCn2/VNkSJNM2OfZDm6c3AVzIsfbou97D\n+KITA562pdASWzSq0kXrLPEjes/NgwbvXc9bWslqNYnz4xxy/YnlYFpA2nAUno1c\nM99p3UgYaaIWk6jZ6iVPMJmgYS0nLKNkL4tbtcGdAoGBAPbc6a64FARYk2sAd03X\nciV8wUbXSr/tKyu98Vrnz+9ERwllN2UNk89dnk1D8mU4VG5wCt3NobmTueH6E3ya\nRAd6goOWOg0ByShoOYIewsEkHRyxyOrVNjX+RojYSmPzCQQ/tuXt/cInBxIC07Dd\nj0RmHPfHZSw6jFt4tcOjv+yV\n-----END PRIVATE KEY-----\n",
+    "client_email": "test-project@wise-weaver-282922.iam.gserviceaccount.com",
+    "client_id": "102252416935570843819",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-project%40wise-weaver-282922.iam.gserviceaccount.com"
+  }


### PR DESCRIPTION
## Description & motivation
Create a working dbt project that calculates various subscription & subscriber metrics from the recharge subscriptions dataset.

## Technical Notes
I could not get the service account file to work correctly creating models (I was able to copy/paste the `target/run` code directly into BQ and execute against my dataset, so likely an issue with the service account; as a workaround, I used Google Oauth.  If you are running my branch directly, you will not be able to authenticate as me and will need to uncomment some lines in `profiles.yml`

## Useful Commands
I added the `dbt_utils` package to the repo for some common macros (`group_by`, etc). You will need to run `dbt deps`.
To run the models/test I created for this project, `dbt_build` will take care of all of it.  The final model you will want to view is `rpt_subscription_metrics` (when reviewing, I created dates to `current_date()`, so you may want to slightly filter this table `where date between '2022-04-03' and '2022-04-07'`


## Considerations
I got close-ish to the numbers provide in the exercise.  However, I made a significant assumption that has downstream affects.  There are several hundred CANCELLED subscriptions that do not have a `cancellation_at` timestamp.  For these, I inserted the `updated_at` timestamp in it's place.  They appeared to be ~1 year after the subscription creation, so it seemed like a reasonable procedure, and it brought my numbers closer to the rubric.

## Other stuff
I threw in a few macros for a calendar (the fields created by macros weren't needed, just wanted to throw them in though).
Additionally, I have placed some tests in various models, mostly `unique` and `not_null`, but added an `accepted values` on the `status` field, because if that starts bringing in new intermediate values, this model would become instable.
Additionally, for time-sake, I did not include any tags, but ordinarily I like adding `staging` tags (as well as `stg_recharge`) and `reporting` tags to mirror my project folder structure.

## Screenshots:
<img width="943" alt="Screen Shot 2022-05-25 at 2 40 53 PM" src="https://user-images.githubusercontent.com/22621309/170374540-f5e13cf0-08ae-4930-9297-372663a8e48d.png">
<img width="1004" alt="Screen Shot 2022-05-25 at 2 40 25 PM" src="https://user-images.githubusercontent.com/22621309/170374616-911337cf-a6bf-4da5-8177-02f9571ad7af.png">

